### PR TITLE
Fix TypeScript error: resolve variable shadowing in project page

### DIFF
--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -74,10 +74,10 @@ export default function ProjectPage() {
         abortControllerRef.current = null;
       }
       setSearching(false);
-      const params = new URLSearchParams(queryParams.toString());
-      params.delete('q');
-      params.set('mode', mode);
-      router.replace(`${pathname}?${params.toString()}`);
+      const urlParams = new URLSearchParams(queryParams.toString());
+      urlParams.delete('q');
+      urlParams.set('mode', mode);
+      router.replace(`${pathname}?${urlParams.toString()}`);
       return;
     }
     
@@ -116,10 +116,10 @@ export default function ProjectPage() {
         setSearching(false);
       }
     }
-    const params = new URLSearchParams(queryParams.toString());
-    params.set('q', query);
-    params.set('mode', mode);
-    router.replace(`${pathname}?${params.toString()}`);
+    const urlParams = new URLSearchParams(queryParams.toString());
+    urlParams.set('q', query);
+    urlParams.set('mode', mode);
+    router.replace(`${pathname}?${urlParams.toString()}`);
   }, [params.projectId]);
 
   const handleQueryChangeImmediate = useCallback((next: string) => {


### PR DESCRIPTION
Fixed "Block-scoped variable 'params' used before its declaration" error by renaming local URLSearchParams instances to 'urlParams' to avoid shadowing the component-level 'params' variable from useParams().

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed internal variables in search handling to improve readability and maintainability.
  * No behavioral changes: search, filters, and navigation continue to function as before.
  * Performance, routing, and query parameter handling remain unaffected.
  * Improves code clarity for future updates and troubleshooting.
  * No user action required; this change has no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->